### PR TITLE
fix #10

### DIFF
--- a/campaign/abstracts.py
+++ b/campaign/abstracts.py
@@ -1,0 +1,27 @@
+# -*- coding: utf-8 -*-
+
+from django.db import models
+from django.utils.translation import ugettext_lazy as _
+
+
+class CampaignAbstract(models.Model):
+
+    name = models.CharField(_("name"), max_length=255)
+    newsletter = models.ForeignKey(
+        'campaign.Newsletter', verbose_name=_("newsletter"), blank=True, null=True)
+    template = models.ForeignKey('campaign.MailTemplate', verbose_name=_("template"))
+
+    recipients = models.ManyToManyField(
+        'campaign.SubscriberList', verbose_name=_("subscriber lists"))
+
+    sent = models.BooleanField(_("sent out"), default=False, editable=False)
+    sent_at = models.DateTimeField(_("sent at"), blank=True, null=True)
+
+    online = models.BooleanField(_("available online"), default=True, blank=True,
+        help_text=_("make a copy available online"))
+
+    class Meta:
+        abstract = True
+
+    def __unicode__(self):
+        return self.name

--- a/campaign/utils.py
+++ b/campaign/utils.py
@@ -1,0 +1,13 @@
+# -*- coding: utf-8 -*-
+
+from six import string_types
+from importlib import import_module
+
+
+def import_model(path_or_callable):
+    if hasattr(path_or_callable, '__call__'):
+        return path_or_callable
+    else:
+        assert isinstance(path_or_callable, string_types)
+        package, attr = path_or_callable.rsplit('.', 1)
+        return getattr(import_module(package), attr)


### PR DESCRIPTION
Registering entry extension
---

You have to register the model extension in `settings.py` adding
`CAMPAIGN_MODEL` with the path of the abstract model.
```python
CAMPAIGN_MODEL = 'youproject.models.CustomCampaignAbstract'
```
Migrations
----

If you extend `Campaign` model you must migrate the database in
order to the see the changes that you made on the model. However if
you perform a ``makemigrations`` operation it will create a migration
in `campaign.migrations` of your local campaign module folder.

So you need to define a new path to store the changes made on
`Campaign` model extension. You have to use
`MIGRATION_MODULES` for this purpose:
```python
MIGRATION_MODULES = {'campaign': 'youproject.campaign_migrations'}
```
After run ``makemigrations campaign`` migrations will appear on ``campaign_migrations`` folder.

It’s recommended that the new initial migration represents the initial campaign migration in order to avoid conflicts when applying ``migrate campaign`` command. A recommend way is run ``makemigrations campaign`` **before** define Campaign model extension on `settings.py` by setting `CAMPAIGN_MODEL`.
