### PR TITLE
add send_campaign permission

### DIFF
--- a/campaign/admin.py
+++ b/campaign/admin.py
@@ -29,9 +29,8 @@ class CampaignAdmin(admin.ModelAdmin):
     def has_send_permission(self, request, obj):
         """
         Subclasses may override this and implement more granular permissions.
-        TODO: integrate with django's permisson system
         """
-        return request.user.is_superuser
+        return request.user.has_perm("campaign.send_campaign")
 
 
     def send_view(self, request, object_id, extra_context=None):

--- a/campaign/migrations/0006_campaign_send_permission.py
+++ b/campaign/migrations/0006_campaign_send_permission.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('campaign', '0005_newsletter_from_name'),
+    ]
+
+    operations = [
+        migrations.AlterModelOptions(
+            name='campaign',
+            options={'ordering': ('name', 'sent'), 'verbose_name': 'campaign', 'verbose_name_plural': 'campaigns', 'permissions': (('send_campaign', 'Can send campaign'),)},
+        ),
+    ]

--- a/campaign/models.py
+++ b/campaign/models.py
@@ -123,6 +123,9 @@ class Campaign(models.Model):
         verbose_name = _("campaign")
         verbose_name_plural = _("campaigns")
         ordering = ('name', 'sent')
+        permissions = (
+            ("send_campaign", _("Can send campaign")),
+        )
 
 
 class BlacklistEntry(models.Model):


### PR DESCRIPTION
Adding a send_campaign permission that can be granted to staff who are not super users to send the campaigns.