### PR TITLE
Django 4 compatibility

### DIFF
--- a/campaign/admin.py
+++ b/campaign/admin.py
@@ -2,7 +2,6 @@ from functools import update_wrapper
 
 from django import forms
 from django.conf import settings
-from django.conf.urls import url
 from django.contrib import admin, messages
 from django.contrib.admin.options import IS_POPUP_VAR
 from django.contrib.admin.utils import unquote
@@ -10,6 +9,7 @@ from django.core.exceptions import PermissionDenied
 from django.core.management import call_command
 from django.http import Http404, HttpResponseRedirect
 from django.shortcuts import render
+from django.urls import re_path
 from django.utils.encoding import force_text
 from django.utils.html import escape
 from django.utils.safestring import mark_safe
@@ -98,7 +98,7 @@ class CampaignAdmin(admin.ModelAdmin):
 
         super_urlpatterns = super(CampaignAdmin, self).get_urls()
         urlpatterns = [
-            url(r'^(.+)/send/$',
+            re_path(r'^(.+)/send/$',
                 wrap(self.send_view),
                 name='%s_%s_send' % info),
         ]
@@ -129,7 +129,7 @@ class BlacklistEntryAdmin(admin.ModelAdmin):
 
         super_urlpatterns = super(BlacklistEntryAdmin, self).get_urls()
         urlpatterns = [
-            url(r'^fetch_mandrill_rejects/$',
+            re_path(r'^fetch_mandrill_rejects/$',
                 wrap(self.fetch_mandrill_rejects),
                 name='%s_%s_fetchmandrillrejects' % info),
         ]
@@ -188,7 +188,7 @@ class SubscriberListAdmin(admin.ModelAdmin):
 
         super_urlpatterns = super(SubscriberListAdmin, self).get_urls()
         urlpatterns = [
-            url(r'^(.+)/preview/$',
+            re_path(r'^(.+)/preview/$',
                 wrap(self.preview_view),
                 name='%s_%s_preview' % info),
         ]

--- a/campaign/admin.py
+++ b/campaign/admin.py
@@ -10,7 +10,7 @@ from django.core.management import call_command
 from django.http import Http404, HttpResponseRedirect
 from django.shortcuts import render
 from django.urls import re_path
-from django.utils.encoding import force_text
+from django.utils.encoding import force_str
 from django.utils.html import escape
 from django.utils.safestring import mark_safe
 from django.utils.translation import gettext as _
@@ -53,14 +53,14 @@ class CampaignAdmin(admin.ModelAdmin):
             raise PermissionDenied
 
         if obj is None:
-            raise Http404(_('%(name)s object with primary key %(key)r does not exist.') % {'name': force_text(opts.verbose_name), 'key': escape(object_id)})
+            raise Http404(_('%(name)s object with primary key %(key)r does not exist.') % {'name': force_str(opts.verbose_name), 'key': escape(object_id)})
 
         if request.method == 'POST':
             if not request.POST.get('send', None) == '1':
                 raise PermissionDenied
 
             num_sent = obj.send()
-            messages.success(request, _('The %(name)s "%(obj)s" was successfully sent. %(num_sent)s messages delivered.' %  {'name': force_text(opts.verbose_name), 'obj': force_text(obj), 'num_sent': num_sent,}))
+            messages.success(request, _('The %(name)s "%(obj)s" was successfully sent. %(num_sent)s messages delivered.' %  {'name': force_str(opts.verbose_name), 'obj': force_str(obj), 'num_sent': num_sent,}))
             return HttpResponseRedirect('../')
 
 
@@ -71,7 +71,7 @@ class CampaignAdmin(admin.ModelAdmin):
         media = self.media + form_media()
 
         context = {
-            'title': _('Send %s') % force_text(opts.verbose_name),
+            'title': _('Send %s') % force_str(opts.verbose_name),
             'object_id': object_id,
             'object': obj,
             'is_popup': (IS_POPUP_VAR in request.POST or IS_POPUP_VAR in request.GET),
@@ -159,10 +159,10 @@ class SubscriberListAdmin(admin.ModelAdmin):
             obj = None
 
         if obj is None:
-            raise Http404(_('%(name)s object with primary key %(key)r does not exist.') % {'name': force_text(opts.verbose_name), 'key': escape(object_id)})
+            raise Http404(_('%(name)s object with primary key %(key)r does not exist.') % {'name': force_str(opts.verbose_name), 'key': escape(object_id)})
 
         context = {
-            'title': _('Preview %s') % force_text(opts.verbose_name),
+            'title': _('Preview %s') % force_str(opts.verbose_name),
             'object_id': object_id,
             'object': obj,
             'is_popup': (IS_POPUP_VAR in request.POST or IS_POPUP_VAR in request.GET),

--- a/campaign/admin.py
+++ b/campaign/admin.py
@@ -13,7 +13,7 @@ from django.shortcuts import render
 from django.utils.encoding import force_text
 from django.utils.html import escape
 from django.utils.safestring import mark_safe
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 
 from campaign.forms import SubscriberListForm
 from campaign.models import (

--- a/campaign/apps.py
+++ b/campaign/apps.py
@@ -1,5 +1,5 @@
 from django.apps import AppConfig
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 
 class CampaignConfig(AppConfig):

--- a/campaign/forms.py
+++ b/campaign/forms.py
@@ -32,7 +32,7 @@ class SubscriberListForm(forms.ModelForm):
             self.add_error(None, _("Either custom_list or content_type and filter_condition must be set"))
 
         if custom_list:  # Check if the defined module does exist and can be initialized, if not throw a hard exception instead of only adding an error
-            import_string(self.custom_list)()
+            import_string(custom_list)()
         else:
             Model = content_type.model_class()
 

--- a/campaign/forms.py
+++ b/campaign/forms.py
@@ -2,7 +2,7 @@ from django import forms
 from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import FieldDoesNotExist, FieldError
 from django.utils.module_loading import import_string
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 
 from campaign.models import SubscriberList
 

--- a/campaign/models.py
+++ b/campaign/models.py
@@ -1,5 +1,5 @@
 from django.db import models
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from django.utils import timezone
 from django.contrib.contenttypes.models import ContentType
 from django.contrib.sites.models import Site
@@ -87,6 +87,7 @@ class SubscriberList(models.Model):
             return import_string(self.custom_list)().object_count()
         else:
             return self.object_list().count()
+
 
     class Meta:
         verbose_name = _("subscriber list")

--- a/campaign/signals.py
+++ b/campaign/signals.py
@@ -1,4 +1,4 @@
 from django.dispatch import Signal
 
-
-campaign_sent = Signal(providing_args=["campaign"])
+# "campaign" Signal
+campaign_sent = Signal()

--- a/tests/urls.py
+++ b/tests/urls.py
@@ -1,8 +1,7 @@
 from django.contrib import admin
-#from django.urls import path, include
-from django.conf.urls import url, include
+from django.urls import path, include
 
 urlpatterns = [
-    url('admin/', admin.site.urls),
-    url('campaign/', include('campaign.urls')),
+    path('admin/', admin.site.urls),
+    path('campaign/', include('campaign.urls')),
 ]


### PR DESCRIPTION
Replaced usages of:

- django.utils.translation.ugettext
- django.utils.translation.ugettext_lazy
- django.utils.encoding.force_text
- django.conf.urls.url


Removed deprecated arg "providing_args" of campaign_sent Signal